### PR TITLE
Use border-radius in default theme

### DIFF
--- a/skins/default/header.css
+++ b/skins/default/header.css
@@ -26,6 +26,7 @@
     border-bottom:      1px solid #000;
     border-left:        1px solid #79c;
     -moz-border-radius: 8px;
+    border-radius:      8px;
     text-align:         center;
     height:             48px;
     width:              48px;
@@ -80,6 +81,7 @@
     border-bottom:      1px solid #68b;
     border-left:        1px solid #002;
     -moz-border-radius: 6px;
+    border-radius:      6px;
     min-width:          225px;
 }
 #help_box {
@@ -98,6 +100,7 @@
     border-bottom:      1px solid #68b;
     border-left:        1px solid #002;
     -moz-border-radius: 8px;
+    border-radius:      8px;
     min-width:          225px;
     white-space:        nowrap;
 }

--- a/skins/default/remote.css
+++ b/skins/default/remote.css
@@ -78,6 +78,7 @@
         white-space:        nowrap;
         -moz-border-radius-topleft:     8px;
         -moz-border-radius-topright:    8px;
+        border-radius:      8px 8px 0px 0px;
     }
     #remote .x-sections a:hover, #remote .x-sections a.x-selected {
         color:              white;

--- a/skins/default/settings.css
+++ b/skins/default/settings.css
@@ -79,6 +79,7 @@
         white-space:        nowrap;
         -moz-border-radius-topleft:     8px;
         -moz-border-radius-topright:    8px;
+        border-radius:      8px 8px 0px 0px;
     }
     #settings .x-sections a:hover, #settings .x-sections a.x-selected {
         color:              white;

--- a/skins/default/status.css
+++ b/skins/default/status.css
@@ -34,6 +34,7 @@ div.content {
     padding:            10px;
     margin-bottom:      30px;
     -moz-border-radius: 8px 0px 0px 8px;
+    border-radius:      8px 0px 0px 8px;
 }
 div.schedule a {
     position:        relative;

--- a/skins/default/welcome.css
+++ b/skins/default/welcome.css
@@ -34,6 +34,7 @@
     border-bottom:      2px solid #48f;
     border-left:        2px solid #48f;
     -moz-border-radius: 8px;
+    border-radius:      8px;
 }
 #module_names li.selected a {
     display:            block;
@@ -46,7 +47,8 @@
     min-width:          314px;
     height:             30em;
     padding:            .5em 1em;
-    -moz-border-radius:     8px;
+    -moz-border-radius: 8px;
+    border-radius:      8px;
 }
 
 .module_icon {


### PR DESCRIPTION
Starting with version 13, Firefox no longer honors the old -moz-border-radius attribute. This adds the standard "border-radius"

http://code.mythtv.org/trac/ticket/10887
