### PR TITLE
Reduce cache headers for program details ajax popup.

### DIFF
--- a/modules/tv/get_show_details.php
+++ b/modules/tv/get_show_details.php
@@ -1,8 +1,8 @@
 <?php
 // Attempt to force some caching, will make secondary views so much faster.
-    header('Cache-Control: max-age-'.($_REQUEST['starttime'] - time() + 604800));
+    header('Cache-Control: max-age=7200, public');
     header('Pragma: ');
-    header('Expires: '.date('D, d M Y H:i:s e', $_REQUEST['starttime'] + 604800));
+    header('Expires: '.date('D, d M Y H:i:s e', time() + 7200));
     header('Content-Type: application/json');
 
     $program = load_one_program($_REQUEST['starttime'], $_REQUEST['chanid'], false);


### PR DESCRIPTION
As it stands, these are being set to 10 days beyond the program start
time.  This means that mythweb will often show stale data for programs
that have been updated since they were initially added to the guide.

This reduces the cache time to 2 hours, which seems like a reasonable
time to cache for, yet still get timely updates.