### PR TITLE
Updated Dockerfile for versioned builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # backends and database connections
 ################################################################################
 
-FROM ubuntu:14.10
+FROM ubuntu:14.04
 MAINTAINER Rob Smith <kormoc@gmail.com>
 
 RUN apt-get update
@@ -30,14 +30,16 @@ EXPOSE 80
 RUN rm -rvf /var/www/html/*
 
 # Pull down bindings
-ADD https://github.com/MythTV/mythtv/raw/master/mythtv/bindings/php/MythBackend.php         /var/www/html/classes/
-ADD https://github.com/MythTV/mythtv/raw/master/mythtv/bindings/php/MythBase.php            /var/www/html/classes/
-ADD https://github.com/MythTV/mythtv/raw/master/mythtv/bindings/php/MythFrontend.php        /var/www/html/classes/
-ADD https://github.com/MythTV/mythtv/raw/master/mythtv/bindings/php/MythTV.php              /var/www/html/classes/
-ADD https://github.com/MythTV/mythtv/raw/master/mythtv/bindings/php/MythTVChannel.php       /var/www/html/classes/
-ADD https://github.com/MythTV/mythtv/raw/master/mythtv/bindings/php/MythTVProgram.php       /var/www/html/classes/
-ADD https://github.com/MythTV/mythtv/raw/master/mythtv/bindings/php/MythTVRecording.php     /var/www/html/classes/
-ADD https://github.com/MythTV/mythtv/raw/master/mythtv/bindings/php/MythTVStorageGroup.php  /var/www/html/classes/
+ENV MYTHTV_BRANCH master
+ENV MYTHTV_SCM_BASE https://raw.githubusercontent.com/MythTV/mythtv/${MYTHTV_BRANCH}
+ADD ${MYTHTV_SCM_BASE}/mythtv/bindings/php/MythBackend.php           /var/www/html/classes/
+ADD ${MYTHTV_SCM_BASE}/mythtv/bindings/php/MythBase.php              /var/www/html/classes/
+ADD ${MYTHTV_SCM_BASE}/mythtv/bindings/php/MythFrontend.php          /var/www/html/classes/
+ADD ${MYTHTV_SCM_BASE}/mythtv/bindings/php/MythTV.php                /var/www/html/classes/
+ADD ${MYTHTV_SCM_BASE}/mythtv/bindings/php/MythTVChannel.php         /var/www/html/classes/
+ADD ${MYTHTV_SCM_BASE}/mythtv/bindings/php/MythTVProgram.php         /var/www/html/classes/
+ADD ${MYTHTV_SCM_BASE}/mythtv/bindings/php/MythTVRecording.php       /var/www/html/classes/
+ADD ${MYTHTV_SCM_BASE}/mythtv/bindings/php/MythTVStorageGroup.php    /var/www/html/classes/
 
 ADD mythweb.conf.apache /etc/apache2/sites-enabled/mythweb.conf
 ADD . /var/www/html


### PR DESCRIPTION
This PR has a few updates to the Dockerfile

* Ubuntu version was changed to 14.04; an Ubuntu LTS branch
* MythTV github server URL was updated
* Created an environment variable for the target MythTV branch to better support building against tagged releases

I ran into some issues building from Ubuntu 14.10 due to some missing repos and wanted to build a `Dockerfile` using MythTV 0.27.5 bindings. 

Tested against master and `v0.27.5` by updating the environment variable and built using 

`docker build -t mythweb:0.27.5`

And ran the container using

`docker run -p 8080:80 -v `pwd`/files/mythweb.conf:/etc/apache2/sites-enabled/mythweb.conf --name mythweb mythweb:0.27.5`