### PR TITLE
Add Satisfy Any to make location work for apache 2.2

### DIFF
--- a/mythweb.conf.apache
+++ b/mythweb.conf.apache
@@ -11,10 +11,12 @@
 #
 #    <LocationMatch .*/pl/stream/[0-9]+/[0-9]+>
 #        Allow from all
+#        Satisfy Any
 #    </LocationMatch>
 #
 #    <LocationMatch .*/music/stream.php>
 #        Allow from all
+#        Satisfy Any
 #    </LocationMatch>
 
 


### PR DESCRIPTION
In order to bypass security in apache 2.2 you need "Satsify Any" as part of the `<location>` tag.  This change updates the default apache conf to use it.