### PR TITLE
Fixes 13126 - A program's category type is not localized.

### DIFF
--- a/modules/tv/tmpl/default/list_cell_program.php
+++ b/modules/tv/tmpl/default/list_cell_program.php
@@ -36,8 +36,8 @@
         echo '</a>';
 
     // Print some additional information for movies
-        if (   strcasecmp($program->category_type, t('movie')) == 0
-            || strcasecmp($program->category_type, t('film'))  == 0) {
+        if (   strcasecmp($program->category_type, 'movie') == 0
+            || strcasecmp($program->category_type, 'film')  == 0) {
             $parens = '';
             if ($program->airdate > 0)
                 $parens = sprintf('%4d', $program->airdate);


### PR DESCRIPTION
This fixes handling of movies so one gets the original airdate and
stars rating on the Listings page.

Signed-off-by: Francois Gouget <fgouget@free.fr>