### PR TITLE
Fixes 13127 - Recognize shows in the 'météo' category as news.

### DIFF
--- a/modules/_shared/lang/French.cat
+++ b/modules/_shared/lang/French.cat
@@ -54,7 +54,7 @@
     \b(?:vari)
 "News"
     Information
-    \b(?:news|info|journal)
+    \b(?:news|m.*t.*o|info|journal)
 "Reality"
     Téléréalité
     \b(?:realit.*)


### PR DESCRIPTION
This puts the weather segments that follow the main news programme in
the right category.

Signed-off-by: Francois Gouget <fgouget@free.fr>