### PR TITLE
[php7.2] Fix PHP 7.2 warnings with disk_size and disk_used.

### DIFF
--- a/modules/tv/recorded.php
+++ b/modules/tv/recorded.php
@@ -179,14 +179,14 @@
     if (function_exists('gmp_mul')) {
     // GMP functions should work better with 64 bit numbers.
         $size = gmp_mul('1024', $size);
-        define(disk_size, gmp_strval($size));
+        define('disk_size', gmp_strval($size));
         $size = gmp_mul('1024', $used);
-        define(disk_used, gmp_strval($size));
+        define('disk_used', gmp_strval($size));
     }
     else {
     // This is inaccurate, but it's the best we can get without GMP.
-        define(disk_size, ($size * 1024));
-        define(disk_used, ($used * 1024));
+        define('disk_size', ($size * 1024));
+        define('disk_used', ($used * 1024));
     }
 
 // Load the class for this page


### PR DESCRIPTION
The recordings page gives two warnings with PHP 7.2:
Use of undefined constant disk_size - assumed 'disk_size' (this will throw an Error in a future version of PHP)!!
Use of undefined constant disk_used - assumed 'disk_used' (this will throw an Error in a future version of PHP)!!

This should also get pulled for fixes/29
Signed-off-by: Joseph Yasi <joe.yasi@gmail.com>