### PR TITLE
[php7.3] Avoid specifying an accidental character range to preg_replace()

### DIFF
--- a/modules/tv/search.php
+++ b/modules/tv/search.php
@@ -457,11 +457,11 @@
             case 'both':
                 return $db->escape($value);
             case 'start':
-                return $db->escape(preg_replace('/[\\s-_]+/', '%', $value).'%');
+                return $db->escape(preg_replace('/[\\s_-]+/', '%', $value).'%');
             case 'end':
-                return $db->escape('%'.preg_replace('/[\\s-_]+/', '%', $value));
+                return $db->escape('%'.preg_replace('/[\\s_-]+/', '%', $value));
             default:
-                return $db->escape('%'.preg_replace('/[\\s-_]+/', '%', $value).'%');
+                return $db->escape('%'.preg_replace('/[\\s_-]+/', '%', $value).'%');
         }
     }
 


### PR DESCRIPTION
This fixes "invalid range in character class at offset 3" starting with PHP 7.3; testcase:

php7.3 -r 'preg_replace("/[\\s-_]+/", "%", "foo");'