### PR TITLE
Escape newlines in title and subtitle for Javascript

### DIFF
--- a/modules/tv/tmpl/default/_advanced_options.php
+++ b/modules/tv/tmpl/default/_advanced_options.php
@@ -34,8 +34,8 @@
         new Ajax.Request('<?php echo root_url ?>tv/lookup_metadata',
                          {
                             parameters: {
-                                              'title'        : "<?php echo $schedule->title ?>",
-                                              'subtitle'     : "<?php echo $schedule->subtitle ?>",
+                                              'title'        : "<?php echo preg_replace('/[\n\r]/', '\\n', $schedule->title) ?>",
+                                              'subtitle'     : "<?php echo preg_replace('/[\n\r]/', '\\n', $schedule->subtitle) ?>",
                                               'inetref'      : $("inetref").value,
                                               'season'       : $("season").value,
                                               'episode'      : $("episode").value,

--- a/modules/tv/tmpl/default/detail.php
+++ b/modules/tv/tmpl/default/detail.php
@@ -106,8 +106,8 @@
         new Ajax.Request('<?php echo root_url ?>tv/lookup_metadata',
                          {
                             parameters: {
-                                              'title'        : "<?php echo $schedule->title ?>",
-                                              'subtitle'     : "<?php echo $schedule->subtitle ?>",
+                                              'title'        : "<?php echo preg_replace('/[\n\r]/', '\\n', $schedule->title) ?>",
+                                              'subtitle'     : "<?php echo preg_replace('/[\n\r]/', '\\n', $schedule->subtitle) ?>",
                                               'inetref'      : "<?php echo ($program ? $program->inetref : $schedule->inetref) ?>",
                                               'season'       : "<?php echo ($program ? $program->season : $schedule->season) ?>",
                                               'episode'      : "<?php echo ($program ? $program->episode : $schedule->episode) ?>",


### PR DESCRIPTION
EPG data for some shows contains newline characters in title and/or subtitle.
Without proper escaping this breaks (and stops) Javascript code execution, i.e. when scheduling a recording toggling "advanced options" does not work:

This errors are shown on the browser console:
```
Uncaught SyntaxError: "" string literal contains an unescaped line break detail:213:84
Uncaught SyntaxError: "" string literal contains an unescaped line break detail:399:84
```
They are caused by:
```   
function detailLookupMetadata() {
        new Ajax.Request('https://example.com/mythweb/tv/lookup_metadata',
                         {
                            parameters: {
                                              'title'        : "The Voice of Germany",
                                              'subtitle'     : "The Voice of Germany
Musikshow, D 2021",
                                              'inetref'      : "",
``` 

and:  
```
function lookupMetadata() {
        [...]
        new Ajax.Request('https://example.com/mythweb/tv/lookup_metadata',
                         {
                            parameters: {
                                              'title'        : "The Voice of Germany",
                                              'subtitle'     : "The Voice of Germany
Musikshow, D 2021",
                                              'inetref'      : $("inetref").value,
``` 
This PR escapes line breaks for title and subtitle.
In the example above only the subtitle contains a linebreak and gets changed to `The Voice of Germany\nMusikshow, D 2021` in javascript.