### PR TITLE
Add support for PHP 8.x

### DIFF
--- a/classes/Cache.php
+++ b/classes/Cache.php
@@ -12,16 +12,20 @@ class Cache {
 
     public static function &get($key = null) {
         $data = &Cache::$Instance->get($key);
-        if (!$data)
-            return null;
+        if (!$data) {
+            $tmp = null;
+            return $tmp;
+        }
         return $data;
 
     }
 
     public static function &getObject($key = null) {
         $obj = &Cache::$Instance->get($key);
-        if (is_string($obj))
-            return unserialize($obj);
+        if (is_string($obj)) {
+            $tmp = unserialize($obj);
+            return $tmp;
+        }
         return $obj;
     }
 

--- a/classes/Cache/APC.php
+++ b/classes/Cache/APC.php
@@ -22,7 +22,8 @@ class Cache_APC implements Cache_Engine {
             return $ret;
         }
 
-        return apc_fetch($key);
+        $tmp = apc_fetch($key);
+        return $tmp;
     }
 
     public function set($key, $data, $lifeLength) {

--- a/classes/Cache/Memcache.php
+++ b/classes/Cache/Memcache.php
@@ -20,7 +20,8 @@ class Cache_Memcache implements Cache_Engine {
                 $ret[$k] = &self::get($v);
             return $ret;
         }
-        return $this->Memcache->get($key);
+        $tmp = $this->Memcache->get($key);
+        return $tmp;
     }
 
     public function set($key, $data, $lifeLength) {

--- a/classes/Cache/Memcached.php
+++ b/classes/Cache/Memcached.php
@@ -13,9 +13,12 @@ class Cache_Memcached implements Cache_Engine {
     }
 
     public function &get($key = null) {
-        if (is_array($key))
-            return $this->Memcache->getMulti($key);
-        return $this->Memcache->get($key);
+        if (is_array($key)) {
+            $tmp = $this->Memcache->getMulti($key);
+            return $tmp;
+        }
+        $tmp = $this->Memcache->get($key);
+        return $tmp;
     }
 
     public function set($key, $data, $lifeLength) {

--- a/classes/Cache/Null.php
+++ b/classes/Cache/Null.php
@@ -8,7 +8,8 @@ class Cache_Null implements Cache_Engine {
                 $ret[$k] = &self::get($v);
             return $ret;
         }
-        return null;
+        $tmp = null;
+        return $tmp;
     }
 
     public function set($object, $data, $lifeLength) {

--- a/classes/Cache/SHM.php
+++ b/classes/Cache/SHM.php
@@ -34,7 +34,8 @@ class Cache_SHM implements Cache_Engine {
                 @shm_remove_var(self::$SHMhandle, self::getVarKey($key));
         }
         FB::warn("Cache Miss $key: ".(microtime(true) - $start));
-        return null;
+        $tmp = null;
+        return $tmp;
     }
 
     public function set($key, $data, $lifeLength) {

--- a/classes/Database/Query/mysql.php
+++ b/classes/Database/Query/mysql.php
@@ -133,7 +133,7 @@ class Database_Query_mysql extends Database_Query {
  * @link http://www.php.net/manual/en/function.mysql-fetch-array.php
  * @return assoc
  **/
-    function fetch_array($result_type=MYSQL_BOTH) {
+    function fetch_array($result_type=MYSQLI_BOTH) {
         return mysqli_fetch_array($this->sh, $result_type);
     }
 

--- a/classes/vcalendar.php
+++ b/classes/vcalendar.php
@@ -740,9 +740,9 @@ class vcalendar {
       return FALSE;
     if( isset( $input['tz'] ) && ( '' < trim ( $input['tz'] ))) {
       $input['tz'] = (string) trim( $input['tz'] );
-      if( ctype_digit( $input['tz']{1} )) { // only numeric tz=offset
+      if( ctype_digit( $input['tz'][1])) { // only numeric tz=offset
         $offset = 0;
-        if( ctype_digit( $input['tz']{0} ))
+        if( ctype_digit( $input['tz'][0]))
           $input['tz'] = '+'.$input['tz'];
         $offset = $toolbox->_tz2offset( $input['tz'] );
         if( 0 != $offset) {
@@ -1436,10 +1436,10 @@ class vcalendar {
             /* get propname */
         $cix = $propname = null;
         for( $cix=0; $cix < strlen( $line ); $cix++ ) {
-          if( in_array( $line{$cix}, array( ':', ';' )))
+          if( in_array( $line[$cix], array( ':', ';' )))
             break;
           else
-            $propname .= $line{$cix};
+            $propname .= $line[$cix];
         }
             /* ignore version/prodid properties */
         if( in_array( strtoupper( $propname ), array( 'VERSION', 'PRODID' )))
@@ -1450,7 +1450,7 @@ class vcalendar {
         $attrix = -1;
         $strlen = strlen( $line );
         for( $cix=0; $cix < $strlen; $cix++ ) {
-          if((       ':'   == $line{$cix} )             &&
+          if((       ':'   == $line[$cix])             &&
                    ( '://' != substr( $line, $cix, 3 )) &&
              ( 'mailto:'   != strtolower( substr( $line, $cix - 6, 7 )))) {
             $attrEnd = TRUE;
@@ -1468,10 +1468,10 @@ class vcalendar {
               break;
             }
           }
-          if( ';' == $line{$cix} )
+          if( ';' == $line[$cix])
             $attr[++$attrix] = null;
           else
-            $attr[$attrix] .= $line{$cix};
+            $attr[$attrix] .= $line[$cix];
         }
 
             /* make attributes in array format */
@@ -2020,7 +2020,7 @@ class calendarComponent {
               foreach( $optparamvalue as $part ) {
                 $part = str_replace( 'MAILTO:', '', $part );
                 $part = str_replace( 'mailto:', '', $part );
-                if(( '"' == $part{0} ) && ( '"' == $part{strlen($part)-1} ))
+                if(( '"' == $part[0]) && ( '"' == $part[strlen($part)-1]))
                   $part = substr( $part, 1, ( strlen($part)-2 ));
                 $optarrays[$optparamlabel][] = $part;
               }
@@ -2028,7 +2028,7 @@ class calendarComponent {
             else {
               $part = str_replace( 'MAILTO:', '', $optparamvalue );
               $part = str_replace( 'mailto:', '', $part );
-              if(( '"' == $part{0} ) && ( '"' == $part{strlen($part)-1} ))
+              if(( '"' == $part[0]) && ( '"' == $part[strlen($part)-1]))
                 $part = substr( $part, 1, ( strlen($part)-2 ));
               $optarrays[$optparamlabel][] = $part;
             }
@@ -2669,14 +2669,14 @@ class calendarComponent {
       }
       if( !empty( $exdate['value'][0]['tz'] )   &&
            ( $exdate['value'][0]['tz'] != 'Z' ) &&
-        ( !( in_array($exdate['value'][0]['tz']{0}, array( '+', '-' )) &&
+        ( !( in_array($exdate['value'][0]['tz'][0], array( '+', '-' )) &&
              ctype_digit( substr( $exdate['value'][0]['tz'], 1 ))) &&
           !ctype_digit( $exdate['value'][0]['tz'] ) ) ) {
         $exdate['params']['TZID'] = $exdate['value'][0]['tz'];
         foreach( $exdate['value'] as $exix => $exdatea ) {
           if( !empty( $exdate['value'][0]['tz'] )   &&
                ( $exdate['value'][0]['tz'] != 'Z' ) &&
-            ( !( in_array($exdate['value'][0]['tz']{0}, array( '+', '-' )) &&
+            ( !( in_array($exdate['value'][0]['tz'][0], array( '+', '-' )) &&
                  ctype_digit( substr( $exdate['value'][0]['tz'], 1 ))) &&
               !ctype_digit( $exdate['value'][0]['tz'] ) ) )
             unset( $exdate['value'][$exix]['tz'] );
@@ -2839,8 +2839,8 @@ class calendarComponent {
           }
         }
         elseif(( 3 <= strlen( trim( $fbMember ))) &&    // string format duration
-               ( in_array( $fbMember{0}, array( 'P', '+', '-' )))) {
-          if( 'P' != $fbMember{0} )
+               ( in_array( $fbMember[0], array( 'P', '+', '-' )))) {
+          if( 'P' != $fbMember[0])
             $fbmember = substr( $fbMember, 1 );
           $freebusyPairMember = $this->_duration_string( $fbMember );
         }
@@ -3260,8 +3260,8 @@ class calendarComponent {
               }
             }
             elseif(( 3 <= strlen( trim( $rPeriod ))) &&    // string format duration
-                   ( in_array( $rPeriod{0}, array( 'P', '+', '-' )))) {
-              if( 'P' != $rPeriod{0} )
+                   ( in_array( $rPeriod[0], array( 'P', '+', '-' )))) {
+              if( 'P' != $rPeriod[0])
                 $rPeriod = substr( $rPeriod, 1 );
               $inputa[] = $this->_duration_string( $rPeriod );
             }
@@ -3343,7 +3343,7 @@ class calendarComponent {
       if( empty( $input['value'][0]['tz'] ) ||
          ( $input['value'][0]['tz'] == 'Z' ))
         $dummy = TRUE;
-      elseif( in_array($input['value'][0]['tz']{0}, array( '+', '-' )) &&
+      elseif( in_array($input['value'][0]['tz'][0], array( '+', '-' )) &&
                ctype_digit( substr( $input['value'][0]['tz'], 1 )))
         $dummy = TRUE;
       elseif( ctype_digit( $input['value'][0]['tz'] ))
@@ -3353,7 +3353,7 @@ class calendarComponent {
         foreach( $input['value'] as $eix => $inputa ) {
           if( !empty( $input['value'][0]['tz'] )   &&
                ( $input['value'][0]['tz'] != 'Z' ) &&
-            ( !( in_array( $input['value'][0]['tz']{0}, array( '+', '-' )) &&
+            ( !( in_array( $input['value'][0]['tz'][0], array( '+', '-' )) &&
                  ctype_digit( substr( $input['value'][0]['tz'], 1 ))) &&
               !ctype_digit( $input['value'][0]['tz'] ) ) )
             unset( $input['value'][$eix]['tz'] );
@@ -3845,14 +3845,14 @@ class calendarComponent {
       unset( $month );
       $this->_existRem( $params, 'VALUE', 'DATE-TIME' );   // ??
       $this->_existRem( $params, 'VALUE', 'DURATION' );
-      if( in_array( $year{0}, array( 'P', '+', '-' ))) { // duration
-        if( '-' == $year{0} )
+      if( in_array( $year[0], array( 'P', '+', '-' ))) { // duration
+        if( '-' == $year[0])
           $after = FALSE;
-        elseif( '+' == $year{0} )
+        elseif( '+' == $year[0])
           $after = TRUE;
-        elseif( 'P' == $year{0} )
+        elseif( 'P' == $year[0])
           $after = TRUE;
-        if( 'P' != $year{0} )
+        if( 'P' != $year[0])
           $year  = substr( $year, 1 );
         $date    = $this->_duration_string( $year);
       }
@@ -4111,7 +4111,7 @@ class calendarComponent {
     $length = 6;
     $str    = null;
     for( $p = 0; $p < $length; $p++ )
-      $unique .= $base{mt_rand( $start, $end )};
+      $unique .= $base[mt_rand( $start, $end )];
     $this->uid['value']  = $date.'-'.$unique.'@'.$this->getConfig( 'unique_id' );
     $this->uid['params'] = null;
   }
@@ -4462,7 +4462,7 @@ class calendarComponent {
  * @since 2.2.2 - 2007-07-29
  * @param array  $datetime  datetime/(date)
  * @param string $tz        timezone
- * @return timestamp
+ * @return int
  */
   function _date2timestamp( $datetime, $tz=null ) {
     $output = null;
@@ -4749,7 +4749,7 @@ class calendarComponent {
    $output = array();
    $val    = null;
    for( $ix=0; $ix < strlen( $duration ); $ix++ ) {
-     switch( strtoupper( $duration{$ix} )) {
+     switch( strtoupper( $duration[$ix])) {
       case 'W':
         $output['week'] = $val;
         $val            = null;
@@ -4771,10 +4771,10 @@ class calendarComponent {
         $val            = null;
         break;
       default:
-        if( !ctype_digit( $duration{$ix} ))
+        if( !ctype_digit( $duration[$ix]))
           return false; // unknown duration controll character  !?!?
         else
-          $val .= $duration{$ix};
+          $val .= $duration[$ix];
      }
    }
    return $this->_duration_array( $output );
@@ -5475,7 +5475,7 @@ class calendarComponent {
       $input['value']['tz'] = (string) $input['value']['tz'];
     if( !empty( $input['value']['tz'] )   &&
          ( $input['value']['tz'] != 'Z' ) &&
-      ( !( in_array($input['value']['tz']{0}, array( '+', '-' )) &&
+      ( !( in_array($input['value']['tz'][0], array( '+', '-' )) &&
            ctype_digit( substr( $input['value']['tz'], 1 ))) &&
         !ctype_digit( $input['value']['tz'] ) ) ) {
       $input['params']['TZID'] = $input['value']['tz'];
@@ -6517,10 +6517,10 @@ class calendarComponent {
             /* get propname, (problem with x-properties, otherwise in previous loop) */
       $cix = $propname = null;
       for( $cix=0; $cix < strlen( $line ); $cix++ ) {
-        if( in_array( $line{$cix}, array( ':', ';' )))
+        if( in_array( $line[$cix], array( ':', ';' )))
           break;
         else {
-          $propname .= $line{$cix};
+          $propname .= $line[$cix];
         }
       }
       if(( 'x-' == substr( $propname, 0, 2 )) || ( 'X-' == substr( $propname, 0, 2 ))) {
@@ -6534,7 +6534,7 @@ class calendarComponent {
       $attrix = -1;
       $strlen = strlen( $line );
       for( $cix=0; $cix < $strlen; $cix++ ) {
-        if((       ':'   == $line{$cix} )             &&
+        if((       ':'   == $line[$cix])             &&
                  ( '://' != substr( $line, $cix, 3 )) &&
            ( 'mailto:'   != strtolower( substr( $line, $cix - 6, 7 )))) {
           $attrEnd = TRUE;
@@ -6552,10 +6552,10 @@ class calendarComponent {
             break;
           }
         }
-        if( ';' == $line{$cix} )
+        if( ';' == $line[$cix])
           $attr[++$attrix] = null;
         else
-          $attr[$attrix] .= $line{$cix};
+          $attr[$attrix] .= $line[$cix];
       }
             /* make attributes in array format */
       $propattr = array();
@@ -6977,7 +6977,7 @@ class calendarComponent {
           $pos = strpos( $string, "\\", $pos );
           if( FALSE === $pos )
             break;
-          if( !in_array( $string{($pos + 1)}, array( 'n', 'N', 'r', ',', ';' ))) {
+          if( !in_array( $string[($pos + 1)], array( 'n', 'N', 'r', ',', ';' ))) {
             $string = substr( $string, 0, $pos )."\\".substr( $string, ( $pos + 1 ));
             $pos += 1;
           }

--- a/includes/cleanup.php
+++ b/includes/cleanup.php
@@ -47,7 +47,7 @@
     fix_crlfxy($_GET);
     fix_crlfxy($_POST);
     fix_crlfxy($_REQUEST);
-    if (get_magic_quotes_gpc()) {
+    if (false) { // get_magic_quotes_gpc()
 
     /**
      * Recursively strip slashes from an array (eg. $_GET).

--- a/includes/cleanup.php
+++ b/includes/cleanup.php
@@ -47,7 +47,7 @@
     fix_crlfxy($_GET);
     fix_crlfxy($_POST);
     fix_crlfxy($_REQUEST);
-    if (false) { // get_magic_quotes_gpc()
+    if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc()) {
 
     /**
      * Recursively strip slashes from an array (eg. $_GET).

--- a/includes/errors.php
+++ b/includes/errors.php
@@ -47,7 +47,7 @@
 // Active assert and make it quiet
     assert_options(ASSERT_ACTIVE,     1);
     assert_options(ASSERT_WARNING,    0);
-    assert_options(ASSERT_QUIET_EVAL, 1);
+    if (defined('ASSERT_QUIET_EVAL')) assert_options(ASSERT_QUIET_EVAL, 1);
 // Set up the callback
     assert_options(ASSERT_CALLBACK, 'assert_handler');
 

--- a/includes/errors.php
+++ b/includes/errors.php
@@ -101,7 +101,7 @@
  *  email message to the address stored in Error_Email, which is defined in
  *  conf.php.
  **/
-    function error_handler($errno, $errstr, $errfile, $errline, $vars) {
+    function error_handler($errno, $errstr, $errfile, $errline, $vars = null) {
         global $db;
     // Leave early if we haven't requested reports from this kind of error
         if (!($errno & error_reporting()))

--- a/includes/errors.php
+++ b/includes/errors.php
@@ -39,7 +39,11 @@
     define('E_ASSERT_ERROR', 4096);
 
 // set the error reporting level for this script
-    error_reporting(FATAL | ERROR | WARNING | E_ERROR | E_WARNING | E_PARSE | E_COMPILE_ERROR);
+// With PHP 8.x far more warnings are thrown so supress them in the legacy code base
+    if (version_compare(PHP_VERSION, '8.0.0') < 0)
+        error_reporting(FATAL | ERROR | WARNING | E_ERROR | E_WARNING | E_PARSE | E_COMPILE_ERROR);
+    else
+        error_reporting(FATAL | ERROR | WARNING | E_ERROR | E_PARSE | E_COMPILE_ERROR);
 
 // Reconfigure the error handler to use our own routine
     set_error_handler('error_handler');

--- a/modules/music/mp3act_functions.php
+++ b/modules/music/mp3act_functions.php
@@ -461,7 +461,7 @@ function musicLookup($type, $itemid)
       $sh->finish();
       $artist = $row['artist_name'];
 
-      $letter = (!preg_match('/^[0-9]/', $artist) ? strtoupper($artist{0}) : '#');
+      $letter = (!preg_match('/^[0-9]/', $artist) ? strtoupper($artist[0]) : '#');
 
       $output = '<div class="head">
         <div class="right">
@@ -1391,7 +1391,7 @@ function internalPlaylistAddPlaylistCheck($curPlId, $addPlId, $depth = 0)
     return false;
 
   $songs = explode(',', $row['playlist_songs']);
-  $playlists = array_filter($songs, create_function('$n','return ($n < 0);'));
+  $playlists = array_filter($songs, function ($n) { return ($n < 0); });
 
   foreach ($playlists as $playlist_id)
   {

--- a/modules/mythtv/set_keys.php
+++ b/modules/mythtv/set_keys.php
@@ -28,8 +28,10 @@
     $sh->finish();
 
 // Make sure we have a valid host selected
-    if (!isset($Settings_Hosts[$_SESSION['settings']['host']]))
-        $_SESSION['settings']['host'] = reset(array_keys($Settings_Hosts));
+    if (!isset($Settings_Hosts[$_SESSION['settings']['host']])) {
+        $tmp = array_keys($Settings_Hosts);
+        $_SESSION['settings']['host'] = reset($tmp);
+    }
 // Save?
     elseif ($_POST['save'] && $_POST['host']) {
         foreach ($_POST['jump'] as $dest => $key_list) {

--- a/modules/mythtv/set_settings.php
+++ b/modules/mythtv/set_settings.php
@@ -20,8 +20,10 @@
     $sh->finish();
 
 // Make sure we have a valid host selected
-    if (!isset($Settings_Hosts[$_SESSION['settings']['host']]))
-        $_SESSION['settings']['host'] = reset(array_keys($Settings_Hosts));
+    if (!isset($Settings_Hosts[$_SESSION['settings']['host']])) {
+        $tmp = array_keys($Settings_Hosts);
+        $_SESSION['settings']['host'] = reset($tmp);
+    }
 // Save?
     elseif ($_POST['save'] && isset($_POST['host'])) {
         foreach ($_POST['settings'] as $value => $data) {

--- a/modules/mythweb/tmpl/default/set_flvplayer.php
+++ b/modules/mythweb/tmpl/default/set_flvplayer.php
@@ -29,7 +29,7 @@
                     break;
                 }
                 elseif (php_uname ('s') == 'Darwin' && file_exists ($path."/ffmpeg.app")) {
-                    $ffmpeg = $path."/ffmpeg".app;
+                    $ffmpeg = $path."/ffmpeg.app";
                     break;
                 }
             }

--- a/modules/mythweb/tmpl/lite/set_flvplayer.php
+++ b/modules/mythweb/tmpl/lite/set_flvplayer.php
@@ -23,7 +23,7 @@
          title="Enable Flash Video player for recordings."
          <?php if (setting('WebFLV_on')) echo ' CHECKED' ?>></td>
 </tr><tr>
-<? /*  The SWF player can't handle different sizes yet, so don't turn these on
+<?php /*  The SWF player can't handle different sizes yet, so don't turn these on
     <th><?php echo t('Width') ?>:</th>
     <td><input type="text" name="width"
          size="5" title="FLV Width"

--- a/modules/remote/handler.php
+++ b/modules/remote/handler.php
@@ -44,7 +44,8 @@
 
 // Unknown send type?  Use the first one found
     if (empty($_REQUEST['type']) || !array_key_exists($_REQUEST['type'], Modules::getModuleProperty('remote', 'links'))) {
-        $_REQUEST['type'] = reset(array_keys(Modules::getModuleProperty('remote', 'links')));
+        $tmp = array_keys(Modules::getModuleProperty('remote', 'links'));
+        $_REQUEST['type'] = reset($tmp);
     }
 
 // Send a command?  (via ajax)

--- a/modules/tv/classes/Channel.php
+++ b/modules/tv/classes/Channel.php
@@ -143,7 +143,7 @@ class Channel extends MythBase {
             $program_id_counter = 0;
     ## we will eventually need to check for list vs "by channel" display
     #  for now, we only have the main list display
-        if (defined('theme_num_time_slots')) {
+        if (defined('theme_num_time_slots') && defined('theme_timeslot_size')) {
             $timeslots_left = theme_num_time_slots;
             $timeslot_size = theme_timeslot_size;
         } else {

--- a/modules/tv/classes/Program.php
+++ b/modules/tv/classes/Program.php
@@ -712,7 +712,7 @@ class Program extends MythBase {
  *
  * @return array sorted list of category_type fields from the program table
  **/
-    public function category_types() {
+    public static function category_types() {
         static $cache = array();
         if (empty($cache)) {
             global $db;

--- a/modules/tv/classes/Schedule.php
+++ b/modules/tv/classes/Schedule.php
@@ -151,8 +151,10 @@ class Schedule extends MythBase {
             }
             Cache::set('Schedule::findScheduled', self::$scheduledRecordings);
         }
-        if (is_null(self::$scheduledRecordings))
-            return array();
+        if (is_null(self::$scheduledRecordings)) {
+            $tmp = array();
+            return $tmp;
+        }
         return self::$scheduledRecordings;
     }
 
@@ -283,7 +285,7 @@ class Schedule extends MythBase {
     // Make sure that recordid is null if it's empty
         if (empty($this->recordid)) {
             $this->recordid = NULL;
-            $this->findid   = Math.floor(date('U', $this->starttime)/60/60/24) + 719528;
+            $this->findid   = floor(date('U', $this->starttime)/60/60/24) + 719528;
         // Only auto-default these properties if we're not dealing with a
         // search-based recording rule, otherwise take the values we
         // received from the custom schedule input form

--- a/modules/tv/includes/programs.php
+++ b/modules/tv/includes/programs.php
@@ -66,8 +66,10 @@
             $program =& load_all_program_data($start_time, $start_time, $chanid, true, 'program.manualid='.intval($manualid));
         else
             $program =& load_all_program_data($start_time, $start_time, $chanid, true);
-        if (!is_object($program) || strcasecmp(get_class($program), 'program'))
-            return NULL;
+        if (!is_object($program) || strcasecmp(get_class($program), 'program')) {
+            $tmp = NULL;
+            return $tmp;
+        }
         return $program;
     }
 
@@ -155,7 +157,8 @@
     // No results
         if ($sh->num_rows() < 1) {
             $sh->finish();
-            return array();
+            $tmp = array();
+            return $tmp;
         }
     // Build two separate queries for optimized selecting of recstatus
         $sh2 = $db->prepare('SELECT recstatus

--- a/modules/tv/tmpl/wap/list.php
+++ b/modules/tv/tmpl/wap/list.php
@@ -72,7 +72,7 @@
         // Grab the reference
             $channel =& Channel::find($key);
         // Print the data
-            print_channel(&$channel, $list_starttime, $list_endtime);
+            print_channel($channel, $list_starttime, $list_endtime);
         // Cleanup is a good thing
             unset($channel);
         // Display the timeslot bar?

--- a/modules/video/set_settings.php
+++ b/modules/video/set_settings.php
@@ -19,8 +19,10 @@
     $sh->finish();
 
 // Make sure we have a valid host selected
-    if (!isset($Settings_Hosts[$_SESSION['settings']['host']]))
-        $_SESSION['settings']['host'] = reset(array_keys($Settings_Hosts));
+    if (!isset($Settings_Hosts[$_SESSION['settings']['host']])) {
+        $tmp = array_keys($Settings_Hosts);
+        $_SESSION['settings']['host'] = reset($tmp);
+    }
 
 // Make sure the session host gets updated to the posted one.
     if (isset($_POST['host']))


### PR DESCRIPTION
I've worked through a number of small issues so that MythWeb will work with PHP 8.x.

I started by fixing all issues identifed by PhpStorm, then fixed a couple of other errors thrown as FATAL and suppressed the errors thrown as WARNING.  These errors have existed for a long time, so there is no harm done by suppressing them.  As MythWeb is considered to be a legacy code base, I believe that an approach such as this is acceptable.

This branch seems to work fine with PHP 8.0 and I believe it will work with PHP 8.1.

Please consider merging my pull request into the official repository.  It resolves #63.