### PR TITLE
Display people in priority order when displaying program details

### DIFF
--- a/modules/tv/classes/Program.php
+++ b/modules/tv/classes/Program.php
@@ -565,12 +565,13 @@ class Program extends MythBase {
     // No cached value -- load it
         if (!isset($this->credits[$role][$add_search_links])) {
         // Get the credits for the requested role
-            $result = $db->query('SELECT people.name
+            $result = $db->query('SELECT UNIQUE(people.name)
                                      FROM credits, people
                                     WHERE credits.person    = people.person
                                       AND credits.role      = ?
                                       AND credits.chanid    = ?
-                                      AND credits.starttime = FROM_UNIXTIME(?)',
+                                      AND credits.starttime = FROM_UNIXTIME(?)
+                                      ORDER BY credits.priority',
                                    $role,
                                    $this->chanid,
                                    $this->starttime


### PR DESCRIPTION
With MythTV commit bf47572d56 (Include actor roles in cast info)
the credits table now maintains the order received from a XMLTV
feed(1).  This patch returns the credits in the order specified
for display purposes.  Because an actor may play multiple
characters in certain shows, only return an actor's name once.

Fixes: #40

(1) All XMLTV grabbers are expected to provide the credits in
    the order of billing to the best of their abilities, which
    is typically limited to their upstream guide source(s).