### PR TITLE
Update mythweb_id cookie to enable SameSite=Strict

### DIFF
--- a/includes/session.php
+++ b/includes/session.php
@@ -19,7 +19,15 @@
     ini_set('session.gc_maxlifetime', 60 * 60 * 24 * 30);   // 30 day timeout on sessions
     session_set_save_handler('sess_do_nothing', 'sess_do_nothing', 'sess_read', 'sess_write', 'sess_destroy', 'sess_gc');
     session_start();
-    setcookie(session_name(), session_id(), time() + 60*60*24*30, '/');     // Update 30 day timeout
+    if (PHP_VERSION_ID < 70300) {
+        setcookie(session_name(), session_id(), time() + 60*60*24*30, '/; SameSite=Strict');     // Update 30 day timeout
+    } else {
+        setcookie(session_name(), session_id(), [
+            'expires' => time() + 60*60*24*30,
+            'path' => '/',
+            'samesite' => 'Strict'
+        ]);
+    }
 
 // Register a destruction handler for the db object, since the guys who write
 // PHP are smoking something and think objects should be destroyed before the


### PR DESCRIPTION
See #72 for more information.

Some things to note:

For PHP versions < 7.3, this abuses the `path` argument to set the `SameSite` attribute.

For PHP versions >= 7.3, `SameSite` can be set in the options array.

I have tested with the former and it is working fine.

I have not tested the latter as I do not have convenient access to a system to do so, so that would need checking.

closes #72
