### PR TITLE
Add Episode Number to hover

### DIFF
--- a/modules/tv/classes/Program.php
+++ b/modules/tv/classes/Program.php
@@ -509,6 +509,12 @@ class Program extends MythBase {
                    ."\t<dd>".html_entities($this->airdate)
                             ."</dd>\n";
         }
+    // Episode Number
+        if (!empty($this->syndicatedepisodenumber)) {
+            $str .= "\t<dt>".t('Episode Number').":</dt>\n"
+                   ."\t<dd>".html_entities($this->syndicatedepisodenumber)
+                            ."</dd>\n";
+        }
     // Category
         if (preg_match('/\\S/', $this->category)) {
             $str .= "\t<dt>".t('Category').":</dt>\n"


### PR DESCRIPTION
A new feature to display the season / episode on hover in the epg. This
makes it easier to figure out if you have seen a show.

Currently the title, subtitle and description etc are displayed on
hover, but there is no episode number.