### PR TITLE
Correctly parse program properties and restore missing flag icons

### DIFF
--- a/modules/tv/classes/Program.php
+++ b/modules/tv/classes/Program.php
@@ -184,29 +184,57 @@ class Program extends MythBase {
             $this->recordedid               = $data['recordedid'];
 
         // These db fields should really get renamed...
-            $this->audioproperties          = $data['stereo'];
-            $this->videoproperties          = $data['hdtv'];
-            $this->subtitletype             = $data['closecaptioned'];
+            $this->audioproperties          = $data['audioprop'];
+            $this->videoproperties          = $data['videoprop'];
+            $this->subtitletype             = $data['subtitletypes'];
         }
     // Assign shortcut names to the new audio/video/subtitle property flags
-        $this->stereo                       = $this->audioproperties & 0x01;
-        $this->mono                         = $this->audioproperties & 0x02;
-        $this->surround                     = $this->audioproperties & 0x04;
-        $this->dolby                        = $this->audioproperties & 0x08;
-        $this->audiohardhear                = $this->audioproperties & 0x10;
-        $this->audiovisimpair               = $this->audioproperties & 0x20;
+    // Check if properties are strings (From MySQL SET columns) or numeric bitflags
+        if (!empty($this->audioproperties) && !is_numeric($this->audioproperties)) {
+        // Parse comma-separated string values from MySQL SET columns
+            $this->stereo         = strpos($this->audioproperties, 'STEREO') !== false;
+            $this->mono           = strpos($this->audioproperties, 'MONO') !== false;
+            $this->surround       = strpos($this->audioproperties, 'SURROUND') !== false;
+            $this->dolby          = strpos($this->audioproperties, 'DOLBY') !== false;
+            $this->audiohardhear  = strpos($this->audioproperties, 'HARDHEAR') !== false;
+            $this->audiovisimpair = strpos($this->audioproperties, 'VISUALIMPAIR') !== false;
+        } elseif (is_numeric($this->audioproperties)) {
+        // Parse numeric bitflags from mythproto (could be string '75' or int 75)
+            $this->stereo         = intval($this->audioproperties) & 0x01;
+            $this->mono           = intval($this->audioproperties) & 0x02;
+            $this->surround       = intval($this->audioproperties) & 0x04;
+            $this->dolby          = intval($this->audioproperties) & 0x08;
+            $this->audiohardhear  = intval($this->audioproperties) & 0x10;
+            $this->audiovisimpair = intval($this->audioproperties) & 0x20;
+        }
 
-        $this->widescreen                   = $this->videoproperties & 0x0001;
-        $this->hdtv                         = $this->videoproperties & 0x0002;
-        $this->avc                          = $this->videoproperties & 0x0008;
-        $this->hd_ready                     = $this->videoproperties & 0x0020;
-        $this->fullhd                       = $this->videoproperties & 0x0040;
-        $this->damaged                      = $this->videoproperties & 0x0400;
+        if (!empty($this->videoproperties) && !is_numeric($this->videoproperties)) {
+            $this->widescreen     = strpos($this->videoproperties, 'WIDESCREEN') !== false;
+            $this->hdtv           = strpos($this->videoproperties, 'HDTV') !== false;
+            $this->avc            = strpos($this->videoproperties, 'AVC') !== false;
+            $this->hd_ready       = strpos($this->videoproperties, '720') !== false;
+            $this->fullhd         = strpos($this->videoproperties, '1080') !== false;
+            $this->damaged        = strpos($this->videoproperties, 'DAMAGED') !== false;
+        } elseif (is_numeric($this->videoproperties)) {
+            $this->widescreen     = intval($this->videoproperties) & 0x0001;
+            $this->hdtv           = intval($this->videoproperties) & 0x0002;
+            $this->avc            = intval($this->videoproperties) & 0x0008;
+            $this->hd_ready       = intval($this->videoproperties) & 0x0020;
+            $this->fullhd         = intval($this->videoproperties) & 0x0040;
+            $this->damaged        = intval($this->videoproperties) & 0x0400;
+        }
 
-        $this->closecaptioned               = $this->subtitletype    & 0x01;
-        $this->has_subtitles                = $this->subtitletype    & 0x02;
-        $this->subtitled                    = $this->subtitletype    & 0x04;
-        $this->deaf_signed                  = $this->subtitletype    & 0x08;
+        if (!empty($this->subtitletype) && !is_numeric($this->subtitletype)) {
+            $this->closecaptioned = strpos($this->subtitletype, 'HARDHEAR') !== false;
+            $this->has_subtitles  = strpos($this->subtitletype, 'NORMAL') !== false;
+            $this->subtitled      = strpos($this->subtitletype, 'ONSCREEN') !== false;
+            $this->deaf_signed    = strpos($this->subtitletype, 'SIGNED') !== false;
+        } elseif (is_numeric($this->subtitletype)) {
+            $this->closecaptioned = intval($this->subtitletype) & 0x01;
+            $this->has_subtitles  = intval($this->subtitletype) & 0x02;
+            $this->subtitled      = intval($this->subtitletype) & 0x04;
+            $this->deaf_signed    = intval($this->subtitletype) & 0x08;
+        }
     // Generate the star string, since mysql has issues with REPEAT() and
     // decimals, and the backend doesn't do it for us, anyway.
         $this->starstring = @str_repeat(star_character, intVal($this->stars * max_stars));

--- a/modules/tv/classes/Program.php
+++ b/modules/tv/classes/Program.php
@@ -79,7 +79,7 @@ class Program extends MythBase {
 
     public function __construct($data) {
         global $db;
-    // This is a mythbackend-formatted program - info about this data structure is stored in libs/libmyth/programinfo.cpp
+    // This is a mythbackend-formatted program - info about this data structure is stored in libs/libmythtv/programtypeflags.h
         if (!isset($data['chanid']) && isset($data[0])) {
         // Load the remaining info we got from mythbackend
             $this->title           = trim($data[0]);    # program name/title
@@ -144,8 +144,8 @@ class Program extends MythBase {
             $this->auto_expire    = ($this->progflags & 0x00000004) ? true : false;    // FL_AUTOEXP        = 0x00000004
             $this->is_editing     = ($this->progflags & 0x00000008) ? true : false;    // FL_EDITING        = 0x00000008
             $this->bookmark       = ($this->progflags & 0x00000010) ? true : false;    // FL_BOOKMARK       = 0x00000010
-            $this->is_recording   = ($this->progflags & 0x00100000) ? true : false;    // FL_INUSERECORDING = 0x00100000
-            $this->is_playing     = ($this->progflags & 0x00200000) ? true : false;    // FL_INUSEPLAYING   = 0x00200000
+            $this->is_recording   = ($this->progflags & 0x01000000) ? true : false;    // FL_INUSERECORDING = 0x01000000
+            $this->is_playing     = ($this->progflags & 0x02000000) ? true : false;    // FL_INUSEPLAYING   = 0x02000000
             $this->is_transcoded  = ($this->progflags & 0x00000100) ? true : false;    // FL_TRANSCODED     = 0x00000100
             $this->is_watched     = ($this->progflags & 0x00000200) ? true : false;    // FL_WATCHED        = 0x00000200
         // Can be deleted?

--- a/modules/tv/tmpl/default/detail.php
+++ b/modules/tv/tmpl/default/detail.php
@@ -275,6 +275,12 @@
                 echo '<img src="'.skin_url.'/img/flags/stereo.png" title="'.t('Stereo').'">';
             if ($program->hdtv)
                 echo '<img src="'.skin_url.'/img/flags/hd.png" title="'.t('HD').'">';
+            if ($program->hd_ready)
+                echo '<img src="'.skin_url.'/img/flags/hd720.png" height=18 title="'.t('720').'">';
+            if ($program->fullhd)
+                echo '<img src="'.skin_url.'/img/flags/hd1080.png" height=18 title="'.t('1080').'">';
+            if ($program->damaged)
+                echo '<img src="'.skin_url.'/img/flags/damaged.png" title="'.t('Damaged').'">';
             if ($program->has_commflag)
                 echo '<img src="'.skin_url.'/img/flags/commflagged.png" title="'.t('Commercials Flagged').'">';
             if ($program->has_cutlist)


### PR DESCRIPTION
The icons for the various program properties weren't displaying correctly due to changes in the formats mythweb was receiving them in. This fixes those.